### PR TITLE
Fix issue with `tag-release.yml`

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Get SDK version and set environment variable
       run: |
-        SDK_VERSION=$(grep 'SDK_VERSION' src/Core/GraphConstants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
+        SDK_VERSION=$(grep 'SDK_VERSION' src/GraphConstants.php |  grep -oE '[0-9]+\.[0-9]+\.([0-9]+|[0-9]+-[a-z]+)')
         echo "SDK_VERSION=$SDK_VERSION" >> $GITHUB_ENV
 
     - name: Create and publish tag


### PR DESCRIPTION
### What does this PR do?

Fix issue with path reference for `GraphConstants.php` which causes the tagging to fail since the file doesn't exist in the `src/Core` directory.