### PR TITLE
Update README with correct package name and version

### DIFF
--- a/scripts/IncrementMinorVersion.php
+++ b/scripts/IncrementMinorVersion.php
@@ -3,9 +3,9 @@
  * Copyright (c) Microsoft Corporation.  All Rights Reserved.
  * Licensed under the MIT License.  See License in the project root
  * for license information.
- * 
- * Bumps up the minor version in src/Core/GraphConstants.php & README based on the latest published package version on Packagist
- * 
+ *
+ * Bumps up the minor version in src/GraphConstants.php & README based on the latest published package version on Packagist
+ *
  * Assumptions:
  *  - Script is run from the repo root
  *  - Script is run on a Unix environment (affects file path separator to files)
@@ -14,17 +14,18 @@
 
 const CONSTANTS_FILEPATH = "./src/GraphConstants.php";
 const SDK_VERSION_VAR_NAME = "SDK_VERSION"; # Name of version variable in GraphConstants.php
-const PACKAGIST_ENDPOINT = "https://packagist.org/packages/microsoft/microsoft-graph-beta.json";
+const PACKAGE_NAME = "microsoft-graph-beta";
+const PACKAGIST_ENDPOINT = "https://packagist.org/packages/microsoft/".PACKAGE_NAME.".json";
 const CONSTANTS_README_FILEPATH = "./README.md";
 
-function getLatestPackagistVersion(): string 
+function getLatestPackagistVersion(): string
 {
     $handle = curl_init();
     curl_setopt($handle, CURLOPT_URL, PACKAGIST_ENDPOINT);
     curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($handle, CURLOPT_TIMEOUT, 100);
     curl_setopt($handle, CURLOPT_FAILONERROR, true);
-    
+
     echo "Fetching latest SDK version from " . PACKAGIST_ENDPOINT . "\n";
     $response = curl_exec($handle);
 
@@ -35,8 +36,8 @@ function getLatestPackagistVersion(): string
     curl_close($handle);
 
     $responseJson = json_decode($response, true);
-    if (!array_key_exists("package", $responseJson) 
-        || !array_key_exists("versions", $responseJson["package"]) 
+    if (!array_key_exists("package", $responseJson)
+        || !array_key_exists("versions", $responseJson["package"])
         || empty($responseJson["package"]["versions"])) {
 
         throw new Exception("Unable to find versions in the packagist response JSON: ". $responseJson);
@@ -53,7 +54,7 @@ function getLatestPackagistVersion(): string
     }
 }
 
-function incrementMinorVersion(string $version): string 
+function incrementMinorVersion(string $version): string
 {
     $splitVersion = explode(".", $version);
     # Increment minor version
@@ -63,7 +64,7 @@ function incrementMinorVersion(string $version): string
     return implode(".", $splitVersion);
 }
 
-function updateGraphConstants(string $version) 
+function updateGraphConstants(string $version)
 {
     $fileContents = file_get_contents(CONSTANTS_FILEPATH);
     if ($fileContents) {
@@ -82,8 +83,8 @@ function updateReadMe(string $version)
 {
     $fileContents = file_get_contents(CONSTANTS_README_FILEPATH);
     if ($fileContents) {
-        $pattern = '/"microsoft\/microsoft-graph":\s+".+"/';
-        $replacement = "\"microsoft/microsoft-graph\": \"^{$version}\"";
+        $pattern = sprintf('/"microsoft\/%s":\s+".+"/', PACKAGE_NAME);
+        $replacement = sprintf("\"microsoft/%s\": \"^{$version}\"", PACKAGE_NAME);
         if (!file_put_contents(CONSTANTS_README_FILEPATH, preg_replace($pattern, $replacement, $fileContents))) {
             throw new Exception("Unable to find and replace SDK version");
         }


### PR DESCRIPTION
Fixes issue where README get overwritten with wrong package name and version due to the v1 package name being used in regexes.