### PR TITLE
Update sdk version to RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You can install the Beta PHP SDK with Composer, either run `composer require mic
 ```
 {
     "require": {
-        "microsoft/microsoft-graph-beta": "^2.0.0-preview"
+        "microsoft/microsoft-graph-beta": "^2.0.0-RC1"
     }
 }
 ```

--- a/src/GraphConstants.php
+++ b/src/GraphConstants.php
@@ -19,5 +19,5 @@ namespace Beta\Microsoft\Graph;
 final class GraphConstants
 {
     const API_VERSION = "beta";
-    const SDK_VERSION = "2.0.0-preview";
+    const SDK_VERSION = "2.0.0-RC1";
 }


### PR DESCRIPTION
Composer considers the preview suffix to be an INVALID version constraint. The RC suffix convention works as expected.