### PR TITLE
Add batch request builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": "^8.0 || ^7.4",
-		"microsoft/microsoft-graph-core": "2.0.0-RC5"
+		"microsoft/microsoft-graph-core": "2.0.0-RC7"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.0 || ^9.0",

--- a/src/BatchRequestBuilder.php
+++ b/src/BatchRequestBuilder.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Graph\Beta;
+
+
+use Microsoft\Graph\Core\Requests\BaseBatchRequestBuilder;
+use Microsoft\Graph\Beta\Generated\Models\ODataErrors\ODataError;
+use Microsoft\Kiota\Abstractions\RequestAdapter;
+
+/**
+ * Class BatchRequestBuilder
+ *
+ * Send requests to Graph's /$batch endpoint
+ *
+ * @package Microsoft\Graph\Beta
+ * @copyright 2023 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://developer.microsoft.com/graph
+ */
+class BatchRequestBuilder extends BaseBatchRequestBuilder
+{
+    /**
+     * Send requests to Graph's /$batch endpoint
+     *
+     * @param RequestAdapter $requestAdapter
+     */
+    public function __construct(RequestAdapter $requestAdapter)
+    {
+         $errorMappings = [
+            '4XX' => [ODataError::class, 'createFromDiscriminatorValue'],
+            '5XX' => [ODataError::class, 'createFromDiscriminatorValue'],
+        ];
+        parent::__construct($requestAdapter, $errorMappings);
+    }
+
+}


### PR DESCRIPTION
extends the Graph Core Base batch request builder while providing error mappings for our generated error models

depends on https://github.com/microsoftgraph/msgraph-sdk-php-core/pull/93

closes https://github.com/microsoftgraph/msgraph-sdk-php/issues/1154