### PR TITLE
Change Graph client constructor to improve initialisation experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Register your application to use the Microsoft Graph API using [Microsoft Azure 
 
 A Token Request Context contains the credentials used to authenticate requests. The SDK supports various contexts that align with OAuth 2.0 flows: `client_credentials`, `authorization_code` and `on_behalf_of` with support for secret-based and certificate-based client authentication.
 
-Under the hood, the Token Request Context is passed to an authentication provider which fetches, caches and refreshes access tokens ensuring all requests are authenticated against the Microsoft Identity platform.
+The Token Request Context is passed to an authentication provider which fetches, caches and refreshes access tokens ensuring all requests are authenticated against the Microsoft Identity platform.
 
 The following sample creates a TokenRequestContext that [gets access without a user](https://docs.microsoft.com/en-us/graph/auth-v2-service?context=graph%2Fapi%2F1.0&view=graph-rest-1.0):
 

--- a/src/GraphServiceClient.php
+++ b/src/GraphServiceClient.php
@@ -25,23 +25,23 @@ use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 class GraphServiceClient extends Generated\BaseGraphClient
 {
     /**
-     * @var RequestAdapter|null
-     */
-    private static ?RequestAdapter $customRequestAdapter = null;
-
-    /**
      * @param TokenRequestContext $tokenRequestContext
      * @param array $scopes
+     * @param RequestAdapter|null $requestAdapter Use createWithRequestAdapter() to set the request adapter.
      */
-    public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [])
+    public function __construct(
+        TokenRequestContext $tokenRequestContext,
+        array $scopes = [],
+        ?RequestAdapter $requestAdapter = null
+    )
     {
-        if (self::$customRequestAdapter) {
-            parent::__construct(self::$customRequestAdapter);
-        } else {
-            parent::__construct(new GraphRequestAdapter(
-                new GraphPhpLeagueAuthenticationProvider($tokenRequestContext, $scopes)
-            ));
+        if ($requestAdapter) {
+            parent::__construct($requestAdapter);
+            return;
         }
+        parent::__construct(new GraphRequestAdapter(
+            new GraphPhpLeagueAuthenticationProvider($tokenRequestContext, $scopes)
+        ));
     }
 
     /**
@@ -51,9 +51,8 @@ class GraphServiceClient extends Generated\BaseGraphClient
      */
     public static function createWithRequestAdapter(RequestAdapter $requestAdapter): GraphServiceClient
     {
-        self::$customRequestAdapter = $requestAdapter;
         $placeholder = new ClientCredentialContext('tenant', 'client', 'secret');
-        return new GraphServiceClient($placeholder);
+        return new GraphServiceClient($placeholder, [], $requestAdapter);
     }
 
     /**

--- a/src/GraphServiceClient.php
+++ b/src/GraphServiceClient.php
@@ -57,6 +57,16 @@ class GraphServiceClient extends Generated\BaseGraphClient
     }
 
     /**
+     * Returns the request adapter instance in use
+     *
+     * @return RequestAdapter
+     */
+    public function getRequestAdapter(): RequestAdapter
+    {
+        return $this->requestAdapter;
+    }
+
+    /**
      * A method that abstracts the /me endpoint and users /users/{{user-id}} under
      * the hood.
      */

--- a/src/GraphServiceClient.php
+++ b/src/GraphServiceClient.php
@@ -9,7 +9,10 @@
 namespace Microsoft\Graph\Beta;
 
 use Microsoft\Graph\Beta\Generated\Users\Item\UserItemRequestBuilder;
+use Microsoft\Graph\Core\Authentication\GraphPhpLeagueAuthenticationProvider;
 use Microsoft\Kiota\Abstractions\RequestAdapter;
+use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
+use Microsoft\Kiota\Authentication\Oauth\TokenRequestContext;
 
 /**
  * Class GraphServiceClient
@@ -22,11 +25,35 @@ use Microsoft\Kiota\Abstractions\RequestAdapter;
 class GraphServiceClient extends Generated\BaseGraphClient
 {
     /**
-     * @param RequestAdapter $requestAdapter
+     * @var RequestAdapter|null
      */
-    public function __construct(RequestAdapter $requestAdapter)
+    private static ?RequestAdapter $customRequestAdapter = null;
+
+    /**
+     * @param TokenRequestContext $tokenRequestContext
+     * @param array $scopes
+     */
+    public function __construct(TokenRequestContext $tokenRequestContext, array $scopes = [])
     {
-        parent::__construct($requestAdapter);
+        if (self::$customRequestAdapter) {
+            parent::__construct(self::$customRequestAdapter);
+        } else {
+            parent::__construct(new GraphRequestAdapter(
+                new GraphPhpLeagueAuthenticationProvider($tokenRequestContext, $scopes)
+            ));
+        }
+    }
+
+    /**
+     * Get an instance of GraphServiceClient that uses $requestAdapter
+     * @param RequestAdapter $requestAdapter
+     * @return GraphServiceClient
+     */
+    public static function createWithRequestAdapter(RequestAdapter $requestAdapter): GraphServiceClient
+    {
+        self::$customRequestAdapter = $requestAdapter;
+        $placeholder = new ClientCredentialContext('tenant', 'client', 'secret');
+        return new GraphServiceClient($placeholder);
     }
 
     /**

--- a/tests/GraphServiceClientTest.php
+++ b/tests/GraphServiceClientTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Microsoft\Graph\Beta\Test;
+
+use Microsoft\Graph\Beta\GraphServiceClient;
+use Microsoft\Kiota\Abstractions\Authentication\AnonymousAuthenticationProvider;
+use Microsoft\Kiota\Authentication\Oauth\ClientCredentialContext;
+use Microsoft\Kiota\Http\GuzzleRequestAdapter;
+use PHPUnit\Framework\TestCase;
+
+class GraphServiceClientTest extends TestCase
+{
+    public function testsInit(): void
+    {
+        $client = GraphServiceClient::createWithRequestAdapter(new GuzzleRequestAdapter(new AnonymousAuthenticationProvider()));
+        $this->assertInstanceOf(GraphServiceClient::class, $client);
+        $testContext = new ClientCredentialContext('tenant', 'client', 'secret');
+        $client = new GraphServiceClient($testContext);
+        $this->assertInstanceOf(GraphServiceClient::class, $client);
+        $client = new GraphServiceClient($testContext, ['Users.Read']);
+        $this->assertInstanceOf(GraphServiceClient::class, $client);
+    }
+}


### PR DESCRIPTION
- Changes client construction experience from:
```php
$authProvider = new PhpLeagueAuthenticationProvider($tokenRequestContext, $scopes);
$requestAdapter = new GraphRequestAdapter($authProvider);
$graphServiceClient = new GraphServiceClient($requestAdapter);
```
to:
```php
$graphServiceClient = new GraphServiceClient($tokenRequestContext, $scopes);
```
- Provides a static builder method to support customising the request adapter (`createWithRequestAdapter`)
- Updates relevant code samples

part of https://github.com/microsoftgraph/msgraph-sdk-php/issues/1214