### PR TITLE
Remove Kiota DOM diff export from shipped files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 /tests export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
+/src/**/kiota-dom-export.txt export-ignore


### PR DESCRIPTION
Removes Kiota DOM export file from shipped package. Currently accounts for `~67MB` when extracted on target machine.

related to https://github.com/microsoftgraph/msgraph-sdk-php/issues/1584